### PR TITLE
Update ObjectOrientedProgrammingDefiningClasses.rst

### DIFF
--- a/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
+++ b/_sources/Introduction/ObjectOrientedProgrammingDefiningClasses.rst
@@ -908,9 +908,9 @@ methods as exercises.
                     bool operator ==(Fraction &otherFrac) {
                         int firstnum = num*otherFrac.den;
                         int secondnum = otherFrac.num*den;
-
-                    }
+                    
                         return firstnum==secondnum;
+                    }
 
                 friend ostream& operator<<(ostream& stream, const Fraction& fraction);
 


### PR DESCRIPTION
Return statement was not enclosed in the block, leading to an error when the code was run. Moved curly bracket to correctly enclose the return statement