### PR TITLE
Fix typo in Self Check Q-9

### DIFF
--- a/_sources/AlgorithmAnalysis/AnAnagramDetectionExample.rst
+++ b/_sources/AlgorithmAnalysis/AnAnagramDetectionExample.rst
@@ -450,7 +450,7 @@ problem.
              int count = 0;
              while (i > 0){
                  count = count + 1;
-                 i = i // 2;
+                 i = i / 2;
              }
              return 0;
          }


### PR DESCRIPTION
Change unintended code comment into division in expression.

<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
Expression :
i = i // 2;
is meant to divide i by 2 but // is an inline code comment in C++, not division

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
